### PR TITLE
Enable the user to specify the collapsed state in the initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ struct Section {
   var items: [String]!
   var collapsed: Bool!
     
-  init(name: String, items: [String]) {
+  init(name: String, items: [String], collapsed: Bool = false) {
     self.name = name
     self.items = items
-    self.collapsed = false
+    self.collapsed = collapsed
   }
 }
     

--- a/ios-swift-collapsible-table-section/CollapsibleTableViewController.swift
+++ b/ios-swift-collapsible-table-section/CollapsibleTableViewController.swift
@@ -33,10 +33,10 @@ class CollapsibleTableViewController: UITableViewController {
         var items: [String]!
         var collapsed: Bool!
         
-        init(name: String, items: [String]) {
+        init(name: String, items: [String], collapsed: Bool = false) {
             self.name = name
             self.items = items
-            self.collapsed = false
+            self.collapsed = collapsed
         }
     }
     


### PR DESCRIPTION
When not specified, the standard value is still false.