### PR TITLE
Performance Improvements and autoresizing cells

### DIFF
--- a/ios-swift-collapsible-table-section/CollapsibleTableViewController.swift
+++ b/ios-swift-collapsible-table-section/CollapsibleTableViewController.swift
@@ -12,9 +12,9 @@ import UIKit
 // MARK: - Section Data Structure
 //
 struct Section {
-    var name: String!
-    var items: [String]!
-    var collapsed: Bool!
+    var name: String
+    var items: [String]
+    var collapsed: Bool
     
     init(name: String, items: [String], collapsed: Bool = false) {
         self.name = name
@@ -32,7 +32,8 @@ class CollapsibleTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        tableView.rowHeight = UITableViewAutomaticDimension
+        tableView.estimatedRowHeight = 44
         self.title = "Apple Products"
         
         // Initialize the sections array
@@ -56,7 +57,7 @@ extension CollapsibleTableViewController {
     }
     
     override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return sections[section].items.count
+        return sections[section].collapsed ? 0 : sections[section].items.count
     }
     
     // Cell
@@ -69,7 +70,7 @@ extension CollapsibleTableViewController {
     }
     
     override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return sections[indexPath.section].collapsed! ? 0 : 44.0
+        return sections[indexPath.section].collapsed ? 0 : UITableViewAutomaticDimension
     }
     
     // Header
@@ -109,11 +110,7 @@ extension CollapsibleTableViewController: CollapsibleTableViewHeaderDelegate {
         header.setCollapsed(collapsed)
         
         // Adjust the height of the rows inside the section
-        tableView.beginUpdates()
-        for i in 0 ..< sections[section].items.count {
-            tableView.reloadRowsAtIndexPaths([NSIndexPath(forRow: i, inSection: section)], withRowAnimation: .Automatic)
-        }
-        tableView.endUpdates()
+        tableView.reloadSections(NSIndexSet(index: section), withRowAnimation: .Automatic)
     }
     
 }


### PR DESCRIPTION
Hi! 

Thanks for the great and simple implementation of a collapsible table view controller. 

I have made some small adjustments which are necessary to ensure the performance of the  embedded table view. 

1. Setting row height to 0 on collapsed
The main issue is that setting the height of non-displayed cells to 0 technically does not move them out of memory. A cell that has height 0 might not be displayed but will still be loaded and if the displayed cells for example depend on synchronous requests to local databases (for example Realm), this will have a huge performance impact. 

Adjusting the number of rows in section based on the section state will only move the cells into memory if they are really displayed. 

2. UITableViewAutomaticDimension
Setting the heightForRowAtIndexPath to UITableViewAutomaticDimension will give us auto resizing cells. The estimated height of the displayed cells can be controlled by setting the estimatedRowHeight = 44 in viewDidLoad()

3. Reloading the section instead of every single row
Reloading the section after toggling will also reload the header view. So if your header depends on the information which is displayed inside the section (for example item count), it will automatically refresh now. 

Best,
Dan.