### PR TITLE
Migrate to Swift 3.0.

### DIFF
--- a/ios-swift-collapsible-table-section.xcodeproj/project.pbxproj
+++ b/ios-swift-collapsible-table-section.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -244,6 +245,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -258,7 +260,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "su.ios-swift-collapsible-table-section";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -271,7 +273,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "su.ios-swift-collapsible-table-section";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/ios-swift-collapsible-table-section/AppDelegate.swift
+++ b/ios-swift-collapsible-table-section/AppDelegate.swift
@@ -14,33 +14,33 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        self.window = UIWindow(frame:UIScreen.mainScreen().bounds)
+        self.window = UIWindow(frame:UIScreen.main.bounds)
         self.window?.makeKeyAndVisible()
         self.window?.rootViewController = UINavigationController(rootViewController: CollapsibleTableViewController())
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/ios-swift-collapsible-table-section/CollapsibleTableViewController.swift
+++ b/ios-swift-collapsible-table-section/CollapsibleTableViewController.swift
@@ -51,30 +51,30 @@ class CollapsibleTableViewController: UITableViewController {
 //
 extension CollapsibleTableViewController {
 
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    override func numberOfSections(in tableView: UITableView) -> Int {
         return sections.count
     }
     
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return sections[section].items.count
     }
     
     // Cell
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("cell") as UITableViewCell? ?? UITableViewCell(style: .Default, reuseIdentifier: "cell")
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell") as UITableViewCell? ?? UITableViewCell(style: .default, reuseIdentifier: "cell")
         
-        cell.textLabel?.text = sections[indexPath.section].items[indexPath.row]
+        cell.textLabel?.text = sections[(indexPath as NSIndexPath).section].items[(indexPath as NSIndexPath).row]
         
         return cell
     }
     
-    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return sections[indexPath.section].collapsed! ? 0 : 44.0
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return sections[(indexPath as NSIndexPath).section].collapsed! ? 0 : 44.0
     }
     
     // Header
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = tableView.dequeueReusableHeaderFooterViewWithIdentifier("header") as? CollapsibleTableViewHeader ?? CollapsibleTableViewHeader(reuseIdentifier: "header")
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: "header") as? CollapsibleTableViewHeader ?? CollapsibleTableViewHeader(reuseIdentifier: "header")
         
         header.titleLabel.text = sections[section].name
         header.arrowLabel.text = ">"
@@ -86,11 +86,11 @@ extension CollapsibleTableViewController {
         return header
     }
     
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 44.0
     }
     
-    override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return 1.0
     }
 
@@ -101,7 +101,7 @@ extension CollapsibleTableViewController {
 //
 extension CollapsibleTableViewController: CollapsibleTableViewHeaderDelegate {
     
-    func toggleSection(header: CollapsibleTableViewHeader, section: Int) {
+    func toggleSection(_ header: CollapsibleTableViewHeader, section: Int) {
         let collapsed = !sections[section].collapsed
         
         // Toggle collapse
@@ -111,7 +111,7 @@ extension CollapsibleTableViewController: CollapsibleTableViewHeaderDelegate {
         // Adjust the height of the rows inside the section
         tableView.beginUpdates()
         for i in 0 ..< sections[section].items.count {
-            tableView.reloadRowsAtIndexPaths([NSIndexPath(forRow: i, inSection: section)], withRowAnimation: .Automatic)
+            tableView.reloadRows(at: [IndexPath(row: i, section: section)], with: .automatic)
         }
         tableView.endUpdates()
     }

--- a/ios-swift-collapsible-table-section/CollapsibleTableViewHeader.swift
+++ b/ios-swift-collapsible-table-section/CollapsibleTableViewHeader.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol CollapsibleTableViewHeaderDelegate {
-    func toggleSection(header: CollapsibleTableViewHeader, section: Int)
+    func toggleSection(_ header: CollapsibleTableViewHeader, section: Int)
 }
 
 class CollapsibleTableViewHeader: UITableViewHeaderFooterView {
@@ -26,8 +26,8 @@ class CollapsibleTableViewHeader: UITableViewHeaderFooterView {
         //
         // Constraint the size of arrow label for auto layout
         //
-        arrowLabel.widthAnchor.constraintEqualToConstant(12).active = true
-        arrowLabel.heightAnchor.constraintEqualToConstant(12).active = true
+        arrowLabel.widthAnchor.constraint(equalToConstant: 12).isActive = true
+        arrowLabel.heightAnchor.constraint(equalToConstant: 12).isActive = true
         
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         arrowLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -50,8 +50,8 @@ class CollapsibleTableViewHeader: UITableViewHeaderFooterView {
         
         contentView.backgroundColor = UIColor(hex: 0x2E3944)
         
-        titleLabel.textColor = UIColor.whiteColor()
-        arrowLabel.textColor = UIColor.whiteColor()
+        titleLabel.textColor = UIColor.white
+        arrowLabel.textColor = UIColor.white
         
         //
         // Autolayout the lables
@@ -61,22 +61,22 @@ class CollapsibleTableViewHeader: UITableViewHeaderFooterView {
             "arrowLabel" : arrowLabel,
         ]
         
-        contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat(
-            "H:|-20-[titleLabel]-[arrowLabel]-20-|",
+        contentView.addConstraints(NSLayoutConstraint.constraints(
+            withVisualFormat: "H:|-20-[titleLabel]-[arrowLabel]-20-|",
             options: [],
             metrics: nil,
             views: views
         ))
         
-        contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat(
-            "V:|-[titleLabel]-|",
+        contentView.addConstraints(NSLayoutConstraint.constraints(
+            withVisualFormat: "V:|-[titleLabel]-|",
             options: [],
             metrics: nil,
             views: views
         ))
         
-        contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat(
-            "V:|-[arrowLabel]-|",
+        contentView.addConstraints(NSLayoutConstraint.constraints(
+            withVisualFormat: "V:|-[arrowLabel]-|",
             options: [],
             metrics: nil,
             views: views
@@ -86,7 +86,7 @@ class CollapsibleTableViewHeader: UITableViewHeaderFooterView {
     //
     // Trigger toggle section when tapping on the header
     //
-    func tapHeader(gestureRecognizer: UITapGestureRecognizer) {
+    func tapHeader(_ gestureRecognizer: UITapGestureRecognizer) {
         guard let cell = gestureRecognizer.view as? CollapsibleTableViewHeader else {
             return
         }
@@ -94,7 +94,7 @@ class CollapsibleTableViewHeader: UITableViewHeaderFooterView {
         delegate?.toggleSection(self, section: cell.section)
     }
     
-    func setCollapsed(collapsed: Bool) {
+    func setCollapsed(_ collapsed: Bool) {
         //
         // Animate the arrow rotation (see Extensions.swf)
         //

--- a/ios-swift-collapsible-table-section/Extensions.swift
+++ b/ios-swift-collapsible-table-section/Extensions.swift
@@ -23,15 +23,15 @@ extension UIColor {
 
 extension UIView {
 
-    func rotate(toValue: CGFloat, duration: CFTimeInterval = 0.2) {
+    func rotate(_ toValue: CGFloat, duration: CFTimeInterval = 0.2) {
         let animation = CABasicAnimation(keyPath: "transform.rotation")
         
         animation.toValue = toValue
         animation.duration = duration
-        animation.removedOnCompletion = false
+        animation.isRemovedOnCompletion = false
         animation.fillMode = kCAFillModeForwards
         
-        self.layer.addAnimation(animation, forKey: nil)
+        self.layer.add(animation, forKey: nil)
     }
 
 }


### PR DESCRIPTION
I would like to display the selected row text in the section header titleLabel. 
assuming the demo application for instance in the Mac Section, lets say i choose MacBook, I would like to see the selected MacBook In the place of Mac section titleLabel. I think this way, the functionality and the intent would be clear in certain scenarios. 

P.S :- I just used your library its fantastic 👍 💯  and I had implemented this feature in my app, But i would like to implement it for all using 👍  