### PR TITLE
Fixed the auto layout issue in header view.

### DIFF
--- a/ios-swift-collapsible-table-section/CollapsibleTableViewHeader.swift
+++ b/ios-swift-collapsible-table-section/CollapsibleTableViewHeader.swift
@@ -27,7 +27,6 @@ class CollapsibleTableViewHeader: UITableViewHeaderFooterView {
         // Constraint the size of arrow label for auto layout
         //
         arrowLabel.widthAnchor.constraint(equalToConstant: 12).isActive = true
-        arrowLabel.heightAnchor.constraint(equalToConstant: 12).isActive = true
         
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         arrowLabel.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
The constraints for arrow label is redundant, it caused some warnings.

For other warnings like the following:
```
2017-06-16 10:09:15.702445 ios-swift-collapsible-table-section[75601:2197719] subsystem: com.apple.UIKit, category: HIDEventFiltered, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
2017-06-16 10:09:15.706746 ios-swift-collapsible-table-section[75601:2197719] subsystem: com.apple.UIKit, category: HIDEventIncoming, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
2017-06-16 10:09:15.710276 ios-swift-collapsible-table-section[75601:2197699] subsystem: com.apple.BaseBoard, category: MachPort, enable_level: 1, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 0, privacy_setting: 0, enable_private_data: 0
2017-06-16 10:09:15.820202 ios-swift-collapsible-table-section[75601:2197652] subsystem: com.apple.siri, category: Intents, enable_level: 1, persist_level: 1, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 0, privacy_setting: 0, enable_private_data: 0
2017-06-16 10:09:15.865936 ios-swift-collapsible-table-section[75601:2197652] subsystem: com.apple.Accessibility, category: AccessibilityBundleLoading, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
2017-06-16 10:09:15.895738 ios-swift-collapsible-table-section[75601:2197652] subsystem: com.apple.UIKit, category: StatusBar, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
2017-06-16 10:09:15.979610 ios-swift-collapsible-table-section[75601:2197652] subsystem: com.apple.BackBoardServices.fence, category: App, enable_level: 1, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 0, privacy_setting: 0, enable_private_data: 0
2017-06-16 10:09:16.203734 ios-swift-collapsible-table-section[75601:2197652] subsystem: com.apple.Accessibility, category: VOTHandwriting, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
```

Please disable the `OS_ACTIVITY_MODE`:
Step 1. Edit scheme (keyboard: cmd + <)
Step 2. At the left choose "Run"
Step 3. At the top right choose "Arguments"

<img width="889" alt="screen shot 2017-06-16 at 10 01 09 am" src="https://user-images.githubusercontent.com/565300/27237235-3831ca5e-527d-11e7-8def-d26da13b47f1.png">
